### PR TITLE
Add rootname define

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -70,9 +70,11 @@
 #elif defined(_WIN64)
 #define GHC_OS_WINDOWS
 #define GHC_OS_WIN64
+#define GHC_HAS_ROOTNAME
 #elif defined(_WIN32)
 #define GHC_OS_WINDOWS
 #define GHC_OS_WIN32
+#define GHC_HAS_ROOTNAME
 #elif defined(__CYGWIN__)
 #define GHC_OS_CYGWIN
 #elif defined(__sun) && defined(__SVR4)
@@ -3221,6 +3223,16 @@ GHC_INLINE path::string_type::size_type path::root_name_length() const noexcept
             return pos;
         }
     }
+
+    // MODIOTEST
+    impl_string_type::size_type posSep = _path.find(preferred_separator);
+    impl_string_type::size_type posCol = _path.find(':');
+    if (posCol != impl_string_type::npos && 
+       ( (posCol != impl_string_type::npos && posCol == posSep - 1) || (posCol+1 == _path.length()) ))
+    {
+        return posCol + 1;
+    }
+
     return 0;
 #endif
 }
@@ -3374,7 +3386,7 @@ GHC_INLINE bool path::has_extension() const
 
 GHC_INLINE bool path::is_absolute() const
 {
-#ifdef GHC_OS_WINDOWS
+#ifdef GHC_HAS_ROOTNAME
     return has_root_name() && has_root_directory();
 #else
     return has_root_directory();

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3224,15 +3224,6 @@ GHC_INLINE path::string_type::size_type path::root_name_length() const noexcept
         }
     }
 
-    // MODIOTEST
-    impl_string_type::size_type posSep = _path.find(preferred_separator);
-    impl_string_type::size_type posCol = _path.find(':');
-    if (posCol != impl_string_type::npos && 
-       ( (posCol != impl_string_type::npos && posCol == posSep - 1) || (posCol+1 == _path.length()) ))
-    {
-        return posCol + 1;
-    }
-
     return 0;
 #endif
 }


### PR DESCRIPTION
Needed for Switch.
Since like Windows , NX got a rootname, i needed is_absolute() to behave like Windows.