### PR TITLE
Ignore not_a_reparse_error if fileattribute is a reparsePoint

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -2288,7 +2288,8 @@ GHC_INLINE std::unique_ptr<REPARSE_DATA_BUFFER, free_deleter<REPARSE_DATA_BUFFER
         return reparseData;
     }
     else {
-        ec = detail::make_system_error();
+        auto error = ::GetLastError();
+        ec = detail::make_system_error(error);
     }
     return nullptr;
 }
@@ -2383,6 +2384,13 @@ GHC_INLINE bool is_symlink_from_INFO(const path &p, const INFO* info, std::error
 {
     if ((info->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
         auto reparseData = detail::getReparseData(p, ec);
+
+        if (ec.value() == ERROR_NOT_A_REPARSE_POINT)
+        {
+            ec.clear();
+            return false;
+        }
+
         if (!ec && reparseData && IsReparseTagMicrosoft(reparseData->ReparseTag) && reparseData->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
             return true;
         }
@@ -2457,7 +2465,8 @@ GHC_INLINE file_status symlink_status_ex(const path& p, std::error_code& ec, uin
     file_status fs;
     WIN32_FILE_ATTRIBUTE_DATA attr;
     if (!GetFileAttributesExW(GHC_NATIVEWP(p), GetFileExInfoStandard, &attr)) {
-        ec = detail::make_system_error();
+		auto error = ::GetLastError();
+		ec = detail::make_system_error(error);
     }
     else {
         ec.clear();
@@ -2503,7 +2512,8 @@ GHC_INLINE file_status status_ex(const path& p, std::error_code& ec, file_status
     }
     WIN32_FILE_ATTRIBUTE_DATA attr;
     if (!::GetFileAttributesExW(GHC_NATIVEWP(p), GetFileExInfoStandard, &attr)) {
-        ec = detail::make_system_error();
+		auto error = ::GetLastError();
+		ec = detail::make_system_error(error);
     }
     else if (attr.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
         auto reparseData = detail::getReparseData(p, ec);
@@ -4506,7 +4516,8 @@ GHC_INLINE uintmax_t file_size(const path& p, std::error_code& ec) noexcept
 #ifdef GHC_OS_WINDOWS
     WIN32_FILE_ATTRIBUTE_DATA attr;
     if (!GetFileAttributesExW(GHC_NATIVEWP(p), GetFileExInfoStandard, &attr)) {
-        ec = detail::make_system_error();
+		auto error = ::GetLastError();
+		ec = detail::make_system_error(error);
         return static_cast<uintmax_t>(-1);
     }
     return static_cast<uintmax_t>(attr.nFileSizeHigh) << (sizeof(attr.nFileSizeHigh) * 8) | attr.nFileSizeLow;


### PR DESCRIPTION

For SteamDeck Integration

"Z:" and "Z:/home" are detected as reparse point by "GetFileAttributesExW" but detail::getReparseData fail with error "ERROR_NOT_A_REPARSE_POINT" , so i return false, if the point is not a reparse point.